### PR TITLE
fix(pom): update groupId for movie-service-utils to com.amazonaws.sam…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.amazonaws.samples</groupId>
+            <groupId>com.amazonaws.sample</groupId>
             <artifactId>movie-service-utils</artifactId>
             <version>0.1.0</version>
         </dependency>


### PR DESCRIPTION
The local installation of movie-service-utils used groupId com.amazonaws.sample, so the dependency declaration in movie-service must match to avoid Maven resolution errors.